### PR TITLE
Makes redundant link test ensure that only one link is tested.

### DIFF
--- a/test/1.internal.HtmlLinkParser.js
+++ b/test/1.internal.HtmlLinkParser.js
@@ -694,6 +694,7 @@ describe("INTERNAL -- HtmlLinkParser", function()
 				},
 				complete: function()
 				{
+					expect(links.length).to.equal(1);
 					expect(links[0].url.original).to.equal("fake.html");
 					expect(links[0].html.attrName).to.equal("href");
 					expect(links[0].html.tag).to.equal('<a href="fake.html">');


### PR DESCRIPTION
 Removes potential false passing testcase that could occur if multiple hrefs were accepted since the test previously only looked at the first item and did not check if a second item was also added.