### PR TITLE
Multiple enqueue

### DIFF
--- a/lib/internal/HtmlLinkParser.js
+++ b/lib/internal/HtmlLinkParser.js
@@ -339,7 +339,7 @@ function reset(instance)
 	_.linkElementStack.length = 0;
 	
 	// Per-link variables
-	_.links.length = 0;
+	_.links = [];
 	_.selector = "";
 	_.voidElement = false;
 }

--- a/lib/internal/HtmlLinkParser.js
+++ b/lib/internal/HtmlLinkParser.js
@@ -38,7 +38,7 @@ function HtmlLinkParser(options, handlers)
 		linkElementStack: [],
 		
 		// Per-link variables
-		links: [],
+		links: [], // `length` not reset because this always points to new arrays
 		selector: "",
 		voidElement: false
 	};

--- a/lib/internal/HtmlLinkParser.js
+++ b/lib/internal/HtmlLinkParser.js
@@ -38,7 +38,7 @@ function HtmlLinkParser(options, handlers)
 		linkElementStack: [],
 		
 		// Per-link variables
-		links: [], // `length` not reset because this always points to new arrays
+		links: [],
 		selector: "",
 		voidElement: false
 	};
@@ -339,7 +339,7 @@ function reset(instance)
 	_.linkElementStack.length = 0;
 	
 	// Per-link variables
-	_.links = [];
+	_.links = []; // `length` not reset because this always points to new arrays
 	_.selector = "";
 	_.voidElement = false;
 }

--- a/lib/internal/HtmlLinkParser.js
+++ b/lib/internal/HtmlLinkParser.js
@@ -339,7 +339,7 @@ function reset(instance)
 	_.linkElementStack.length = 0;
 	
 	// Per-link variables
-	_.links = []; // `length` not reset because this always points to new arrays
+	_.links = [];  // `length` not reset because this always points to new arrays
 	_.selector = "";
 	_.voidElement = false;
 }

--- a/lib/public/HtmlUrlChecker.js
+++ b/lib/public/HtmlUrlChecker.js
@@ -31,6 +31,7 @@ function HtmlUrlChecker(options, handlers)
 			thisObj.currentCustomData = input.data.customData;
 			thisObj.currentDone = done;
 			thisObj.currentHtmlUrl = input.url;
+			resetHtmlLinkChecker(thisObj);
 			
 			// TODO :: make callback reusable
 			getHtmlFromUrl(thisObj.currentHtmlUrl, thisObj.options, function(error, htmlString, responseUrl)
@@ -56,17 +57,7 @@ function HtmlUrlChecker(options, handlers)
 		}
 	});
 	
-	this.htmlChecker = new HtmlChecker(this.options,
-	{
-		link: function(result)
-		{
-			callHandler.sync(thisObj.handlers.link, [result, thisObj.currentCustomData]);
-		},
-		complete: function()
-		{
-			complete(thisObj, null);
-		}
-	});
+	resetHtmlLinkChecker(thisObj);
 }
 
 
@@ -146,6 +137,23 @@ function reset(instance)
 	instance.currentCustomData = null;
 	instance.currentDone = null;
 	instance.currentHtmlUrl = null;
+}
+
+
+
+function resetHtmlLinkChecker(thisObj)
+{
+	thisObj.htmlChecker = new HtmlChecker(thisObj.options,
+	{
+		link: function(result)
+		{
+			callHandler.sync(thisObj.handlers.link, [result, thisObj.currentCustomData]);
+		},
+		complete: function()
+		{
+			complete(thisObj, null);
+		}
+	});
 }
 
 

--- a/lib/public/HtmlUrlChecker.js
+++ b/lib/public/HtmlUrlChecker.js
@@ -31,7 +31,6 @@ function HtmlUrlChecker(options, handlers)
 			thisObj.currentCustomData = input.data.customData;
 			thisObj.currentDone = done;
 			thisObj.currentHtmlUrl = input.url;
-			resetHtmlLinkChecker(thisObj);
 			
 			// TODO :: make callback reusable
 			getHtmlFromUrl(thisObj.currentHtmlUrl, thisObj.options, function(error, htmlString, responseUrl)
@@ -57,7 +56,17 @@ function HtmlUrlChecker(options, handlers)
 		}
 	});
 	
-	resetHtmlLinkChecker(thisObj);
+	this.htmlChecker = new HtmlChecker(this.options,
+	{
+		link: function(result)
+		{
+			callHandler.sync(thisObj.handlers.link, [result, thisObj.currentCustomData]);
+		},
+		complete: function()
+		{
+			complete(thisObj, null);
+		}
+	});
 }
 
 
@@ -137,23 +146,6 @@ function reset(instance)
 	instance.currentCustomData = null;
 	instance.currentDone = null;
 	instance.currentHtmlUrl = null;
-}
-
-
-
-function resetHtmlLinkChecker(thisObj)
-{
-	thisObj.htmlChecker = new HtmlChecker(thisObj.options,
-	{
-		link: function(result)
-		{
-			callHandler.sync(thisObj.handlers.link, [result, thisObj.currentCustomData]);
-		},
-		complete: function()
-		{
-			complete(thisObj, null);
-		}
-	});
 }
 
 

--- a/test/6.public.HtmlUrlChecker.js
+++ b/test/6.public.HtmlUrlChecker.js
@@ -299,8 +299,8 @@ describe("PUBLIC -- HtmlUrlChecker", function()
 		
 		it("should support pages after html with no links", function(done)
 		{
-			var linkCount = 0;
 			var itemCount = 0;
+			var linkCount = 0;
 			
 			var instance = new HtmlUrlChecker( utils.options(),
 			{
@@ -314,8 +314,8 @@ describe("PUBLIC -- HtmlUrlChecker", function()
 				},
 				end: function()
 				{
-					expect(linkCount).to.equal(2);
 					expect(itemCount).to.equal(2);
+					expect(linkCount).to.equal(2);
 					done();
 				}
 			});

--- a/test/6.public.HtmlUrlChecker.js
+++ b/test/6.public.HtmlUrlChecker.js
@@ -297,6 +297,34 @@ describe("PUBLIC -- HtmlUrlChecker", function()
 		
 		
 		
+		it("should support pages after html with no links", function(done)
+		{
+			var count = 0;
+			var itemCalled = false;
+			
+			var instance = new HtmlUrlChecker( utils.options(),
+			{
+				link: function()
+				{
+					count++;
+				},
+				item: function()
+				{
+					itemCalled = true;
+				},
+				end: function()
+				{
+					expect(itemCalled).to.be.true;
+					expect(count).to.equal(0);
+					done();
+				}
+			});
+			instance.enqueue( conn.absoluteUrl+"/fixtures/link-real.html" );
+			instance.enqueue( conn.absoluteUrl+"/fixtures/index.html" );
+		});
+		
+		
+		
 		it("should report error when html could not be retrieved", function(done)
 		{
 			var itemCalled = false;

--- a/test/6.public.HtmlUrlChecker.js
+++ b/test/6.public.HtmlUrlChecker.js
@@ -300,7 +300,7 @@ describe("PUBLIC -- HtmlUrlChecker", function()
 		it("should support pages after html with no links", function(done)
 		{
 			var count = 0;
-			var itemCalled = false;
+			var itemCalled = 0;
 			
 			var instance = new HtmlUrlChecker( utils.options(),
 			{
@@ -310,12 +310,12 @@ describe("PUBLIC -- HtmlUrlChecker", function()
 				},
 				item: function()
 				{
-					itemCalled = true;
+					itemCalled++;
 				},
 				end: function()
 				{
-					expect(itemCalled).to.be.true;
-					expect(count).to.equal(0);
+					expect(count).to.equal(2);
+					expect(itemCalled).to.equal(2);
 					done();
 				}
 			});

--- a/test/6.public.HtmlUrlChecker.js
+++ b/test/6.public.HtmlUrlChecker.js
@@ -299,26 +299,27 @@ describe("PUBLIC -- HtmlUrlChecker", function()
 		
 		it("should support pages after html with no links", function(done)
 		{
-			var count = 0;
-			var itemCalled = 0;
+			var linkCount = 0;
+			var itemCount = 0;
 			
 			var instance = new HtmlUrlChecker( utils.options(),
 			{
 				link: function()
 				{
-					count++;
+					linkCount++;
 				},
 				item: function()
 				{
-					itemCalled++;
+					itemCount++;
 				},
 				end: function()
 				{
-					expect(count).to.equal(2);
-					expect(itemCalled).to.equal(2);
+					expect(linkCount).to.equal(2);
+					expect(itemCount).to.equal(2);
 					done();
 				}
 			});
+
 			instance.enqueue( conn.absoluteUrl+"/fixtures/link-real.html" );
 			instance.enqueue( conn.absoluteUrl+"/fixtures/index.html" );
 		});


### PR DESCRIPTION
Previously if you enqueued multiple items in UrlLinkChecker and one of them had no links on the page, any future page checks would crash. This fixes the issue by rebuilding the LinkChecker per page.