### PR TITLE
Adds test runner option

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "node": ">= 0.10"
   },
   "scripts": {
-    "test": "mocha test/ --reporter spec --check-leaks --bail"
+    "test": "mocha test/ --reporter spec --check-leaks --bail",
+    "test-watch": "mocha test/ --reporter spec --check-leaks --bail -w"
   },
   "files": [
     "bin",


### PR DESCRIPTION
This fixes #11.

It turns out that `mocha` already had a -w switch, so this just adds an entry into package.json to make it a bit more obvious.