### PR TITLE
Add ability to use 'get' retrieval verb instead of 'head'

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,11 @@ Type: `Number`
 Default value: `0`  
 The number of milliseconds to wait before each request.
 
+### options.requestMethod
+Type: `String`  
+Default value: `"head"`  
+The HTTP request method used in checking links. Some sites do not respond correctly to `"head"`, while `"get"` can provide more consistent and accurate results, albeit slower.
+
 
 ## Handling link errors
 Each result will have its own `error` key for which you can compare against:
@@ -228,7 +233,6 @@ if (result.error !== null) {
 * option to exclude keywords from URLs (facebook.com, etc)
 * change order of checking to: tcp error, 4xx code (broken), 5xx code (undetermined), 200
 * option to scrape `response.body` for erroneous sounding text (since an error page could be presented but still have code 200)
-* option to check using GET instead of HEAD as it's more reliable (some sites do not respond correctly--like "method not supported" or always 200--to HEAD)
 * option to check broken link on archive.org for archived version (using [this lib](https://npmjs.com/archive.org))
 * option to include iframe HTML source in checking?
 * option to run `HtmlUrlChecker` checks on page load (using [jsdom](https://npmjs.com/jsdom)) to include links added with JavaScript

--- a/lib/internal/checkUrl.js
+++ b/lib/internal/checkUrl.js
@@ -53,7 +53,7 @@ function checkUrl(link, baseUrl, options, cache, callback)
 	bhttp.request(link.url.resolved,  // TODO :: https://github.com/joepie91/node-bhttp/issues/3
 	{
 		headers: { "user-agent":options.userAgent },
-		method: "head"
+		method: options.requestMethod
 	},
 	function(error, response)
 	{

--- a/lib/internal/defaultOptions.js
+++ b/lib/internal/defaultOptions.js
@@ -16,6 +16,7 @@ var defaultOptions =
 	maxSockets: Infinity,
 	maxSocketsPerHost: 1,
 	rateLimit: 0,
+	requestMethod: "head",
 	tags: require("./tags"),
 	userAgent: userAgent(pkg.name, pkg.version)
 };


### PR DESCRIPTION
commit 8a4dfb0ed094b6ff3c491d89f2446a4905552771
Author: Mark Katerberg <katerberg@Ghosty.local>
Date:   Mon Jul 27 13:35:17 2015 -0500

    updates request method option name

commit e4d03c0cb67dc3555649ca68e2642d9f6cfa5ce9
Merge: a6cefef 1ddcc02
Author: Mark Katerberg <katerberg@Ghosty.local>
Date:   Mon Jul 27 13:32:14 2015 -0500

    Merge remote-tracking branch 'origin/master' into option_to_get

commit a6cefef27fd5748772fd8949c81b9418b08d8ae8
Author: Mark Katerberg <katerberg@Ghosty.local>
Date:   Mon Jul 20 15:58:36 2015 -0500

    adds option to use 'get' instead of 'head' while scanning