### PR TITLE
Use Object.prototype.hasOwnProperty; not on object

### DIFF
--- a/lib/internal/linkObj.js
+++ b/lib/internal/linkObj.js
@@ -3,6 +3,7 @@ var isString = require("is-string");
 var urllib = require("url");
 var urlobj = require("urlobj");
 
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 
 function linkObj(url)
@@ -236,7 +237,7 @@ function cloneObject(source)
 	// TODO :: use Object.keys() for more speed
 	for (key in source)
 	{
-		if (source.hasOwnProperty(key) === true)
+		if (hasOwnProperty.call(source, key) === true)
 		{
 			value = source[key];
 			


### PR DESCRIPTION
As of Node 6, querystring.parse() returns an object with no prototype,
which means that it doesn't have its own hasOwnProperty()

https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#querystring

Fixes #31. Note: requires the fixes in https://github.com/stevenvachon/urlobj/pull/3 to pass all tests on Node 6.