### PR TITLE
Disable spinner when CONTINUOUS_INTEGRATION envvar is set

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -483,9 +483,11 @@ function run(url, checkerOptions, logOptions)
 	{
 		instance = new blc.SiteChecker(checkerOptions, handlers);
 	}
-	
-	spinner();
-	
+
+	if (process.env.CONTINUOUS_INTEGRATION === undefined) {
+		spinner();
+	}
+
 	instance.enqueue(url);
 }
 


### PR DESCRIPTION
This should address concerns expressed in #26 by disabling the spinner on Travis (and possibly other CI solutions that set the CONTINUOUS_INTEGRATION environment variable).