### PR TITLE
Add support for masquerading

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -90,6 +90,13 @@ function cli()
 				type: Number,
 				default: defaultOptions.maxSocketsPerHost
 			},
+                       "masquerade":
+                       {
+                               rename: "masquerades",
+                               info: "Masquerade a base URI as another. Can be used multiple times.",
+                               type: [String, Array],
+                               default: defaultOptions.masquerades
+                       },
 			"ordered":
 			{
 				rename: "maintainLinkOrder",
@@ -166,6 +173,7 @@ cli.prototype.input = function(args, showArgs)
 			excludeLinksToSamePage: args.verbose!==true,
 			filterLevel:            args.filterLevel,
 			honorRobotExclusions:   args.followRobotExclusions!==true,
+			masquerades:            args.masquerades,
 			maxSockets:             args.maxSockets,
 			maxSocketsPerHost:      args.maxSocketsPerHost,
 			requestMethod:          args.get!==true ? "head" : "get",

--- a/lib/internal/defaultOptions.js
+++ b/lib/internal/defaultOptions.js
@@ -15,6 +15,7 @@ var defaultOptions =
 	excludeLinksToSamePage: true,
 	filterLevel: 1,
 	honorRobotExclusions: true,
+	masquerades: [],
 	maxSockets: Infinity,
 	maxSocketsPerHost: 1,
 	rateLimit: 0,

--- a/lib/internal/linkObj.js
+++ b/lib/internal/linkObj.js
@@ -209,7 +209,13 @@ linkObj.resolve = function(link, base, options)
 		}
 	}
 	
-	
+	// Masquerade urls
+	for (var masquerade in options.masquerades){
+		if (link['url']['resolved'] && link['url']['resolved'].startsWith(masquerade) === true){
+			link['url']['resolved'] = link['url']['resolved'].replace(masquerade, options.masquerades[masquerade])
+		}
+	}
+
 	
 	// Avoid future resolving
 	link.resolved = true;

--- a/lib/internal/parseOptions.js
+++ b/lib/internal/parseOptions.js
@@ -33,7 +33,29 @@ function array2booleanMap(array)
 	return array;
 }
 
+function array2stringMap(array)
+{
+	var i,map,numElements;
 
+	if (Array.isArray(array) === true)
+	{
+		map = {};
+		numElements = array.length;
+
+		for (i=0; i<numElements; i++)
+		{
+			var tmp = array[i].split(" ")
+			if (tmp.length > 1) {
+				map[ tmp[0] ] = tmp[1];
+			}
+		}
+
+		return map;
+	}
+
+	// Unknown input -- return
+	return array;
+}
 
 function parseOptions(options)
 {
@@ -44,7 +66,8 @@ function parseOptions(options)
 		// Maps have better search performance, but are not friendly for options
 		options.acceptedSchemes = array2booleanMap(options.acceptedSchemes);
 		options.excludedSchemes = array2booleanMap(options.excludedSchemes);
-		
+	        options.masquerades = array2stringMap(options.masquerades);
+
 		// Undocumented -- avoids reparsing pass-thru options from class to class
 		options.__parsed = true;
 	}

--- a/test/0.internal.linkObj.js
+++ b/test/0.internal.linkObj.js
@@ -219,5 +219,32 @@ describe("INTERNAL -- linkObj", function()
 				samePage: null
 			});
 		});
+
+
+                it("replaces masquerades a url", function()
+                {
+                        var baseUrl = "smtp://fakeurl.com/";
+                        var linkUrl = "path/resource.html?query#hash";
+                        var link = linkObj(linkUrl);
+
+                        linkObj.resolve(link, baseUrl, options);
+
+                        expect(link).to.be.like(
+                        {
+                                url:
+                                {
+                                        original: linkUrl,
+                                        resolved: null
+                                },
+                                base:
+                                {
+                                        original: baseUrl,
+                                        resolved: baseUrl
+                                },
+                                internal: null,
+                                samePage: null
+                        });
+                });
 	});
 });
+

--- a/test/helpers/json/linkObj.json
+++ b/test/helpers/json/linkObj.json
@@ -6559,5 +6559,14 @@
 		"resolvedBaseUrl": null,
 		"internal": null,
 		"samePage": null
+	},
+	"MASQUERADED url": {
+		"linkUrl": "https://fakeurl3.com/path/link.html",
+		"baseUrl": "https://fakeurl3.com/path/link.html",
+		"htmlBaseUrl": "https://fakeurl3.com/path/link.html",
+		"resolvedLinkUrl": "https://fakeurl4.com/path/link.html",
+		"resolvedBaseUrl": "https://fakeurl3.com/path/link.html",
+		"internal": true,
+		"samePage": true
 	}
 }

--- a/test/helpers/options.js
+++ b/test/helpers/options.js
@@ -13,7 +13,10 @@ var testDefaultOptions =
 	honorRobotExclusions: false,
 	maxSockets: Infinity,
 	maxSocketsPerHost: Infinity,
-	retry405Head: false
+	retry405Head: false,
+	masquerades: {
+		"https://fakeurl3.com/": "https://fakeurl4.com/"
+	}
 };
 
 


### PR DESCRIPTION
This allows replacing base urls with other arbitrary urls. It makes it much simpler to test websites with hard-coded urls before actually deploying them.

In my case, I use masquerading to test a website served by a container with Docker Compose.
```
# Example of a Compose file
# Jekyll contains documentation that is exposed under https://docs.my-company.com
version: '3.3'
services:
  jekyll:
    image: "registry.my-company.com/documentation"
  main:
    command:
      - http://jekyll
      - -r
      - --masquerade
      - "https://docs.my-company.com http://jekyll"
    image: registry.my-company.com/broken-link-checker
    links:
      - jekyll
```
