### PR TITLE
log broken links to file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,6 +2,7 @@
 var blc            = require("./");
 var defaultOptions = require("./internal/defaultOptions");
 var pkg            = require("../package.json");
+var logToFile 	   = require("./internal/logToFile");
 
 var chalk = require("chalk");
 var humanizeDuration = require("humanize-duration");
@@ -220,7 +221,17 @@ function logMetrics(brokenLinks, excludedLinks, totalLinks, duration, preBreak, 
 		output += chalk.gray("\nElapsed time: ");
 		output += chalk.gray( humanizeDuration(duration, {round:true, largest:2}) );
 	}
-	
+
+	if(brokenLinks > 0)
+	{
+		logToFile.addToBrokenLogs(output);
+		logToFile.write();
+	}
+	else
+	{
+		logToFile.clearData()
+	}
+
 	log(output);
 
 	if (exit === true)
@@ -253,6 +264,8 @@ function logPage(data, pageUrl)
 	output += chalk.white("Getting links from: ") + chalk.yellow(pageUrl);
 	
 	log(output);
+
+	logToFile.addToBrokenLogs(output);
 }
 
 
@@ -304,6 +317,10 @@ function logResult(result, finalResult)
 		else if (result.http.cached === true)
 		{
 			output += chalk.gray(" (CACHED)");
+		}
+
+		if(result.broken === true){
+			logToFile.addToBrokenLogs(output)
 		}
 	}
 	

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -231,7 +231,13 @@ function logMetrics(brokenLinks, excludedLinks, totalLinks, duration, preBreak, 
 		output += chalk.gray( humanizeDuration(duration, {round:true, largest:2}) );
 	}
 
-	logToFile.addToBrokenLogs(output);
+	//write to log file if broken links found, true indicates it should flush the log
+	if(brokenLinks>0){
+		logToFile.addToBrokenLogs(output, true);
+	}
+
+	//clear log to file buffer
+	logToFile.clearData();
 
 	log(output);
 
@@ -266,6 +272,7 @@ function logPage(data, pageUrl)
 	
 	log(output);
 
+	//add line to file log buffer
 	logToFile.addToBrokenLogs(output);
 }
 
@@ -319,7 +326,7 @@ function logResult(result, finalResult)
 		{
 			output += chalk.gray(" (CACHED)");
 		}
-
+		//add only broken results to file log buffer
 		if(result.broken === true){
 			logToFile.addToBrokenLogs(output)
 		}
@@ -410,6 +417,7 @@ function resetPageData(data)
 
 function run(url, checkerOptions, logOptions)
 {	
+	//set shouldLogToFile
 	logToFile.enable(checkerOptions.shouldLogBroken);
 	var handlers,instance;
 	var data = 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -104,6 +104,14 @@ function cli()
 				info: "Recursively scan (\"crawl\") the HTML document(s).",
 				type: Boolean
 			},
+			"log-broken-links":
+			{
+				rename: "shouldLogBroken",
+				short: "b",
+				info: "Log broken links to file",
+				type: Boolean,
+				default: defaultOptions.shouldLogBroken
+			},
 			"requests":
 			{
 				rename: "maxSockets",
@@ -167,6 +175,7 @@ cli.prototype.input = function(args, showArgs)
 			excludeLinksToSamePage: args.verbose!==true,
 			filterLevel:            args.filterLevel,
 			honorRobotExclusions:   args.followRobotExclusions!==true,
+			shouldLogBroken:		args.shouldLogBroken===true,
 			maxSockets:             args.maxSockets,
 			maxSocketsPerHost:      args.maxSocketsPerHost,
 			requestMethod:          args.get!==true ? "head" : "get",
@@ -408,7 +417,8 @@ function resetPageData(data)
 
 
 function run(url, checkerOptions, logOptions)
-{
+{	
+	logToFile.enable(checkerOptions.shouldLogBroken);
 	var handlers,instance;
 	var data = 
 	{

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -231,10 +231,7 @@ function logMetrics(brokenLinks, excludedLinks, totalLinks, duration, preBreak, 
 		output += chalk.gray( humanizeDuration(duration, {round:true, largest:2}) );
 	}
 
-	if(brokenLinks > 0)
-	{
-		logToFile.addToBrokenLogs(output);
-	}
+	logToFile.addToBrokenLogs(output);
 
 	log(output);
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -234,11 +234,6 @@ function logMetrics(brokenLinks, excludedLinks, totalLinks, duration, preBreak, 
 	if(brokenLinks > 0)
 	{
 		logToFile.addToBrokenLogs(output);
-		logToFile.write();
-	}
-	else
-	{
-		logToFile.clearData()
 	}
 
 	log(output);

--- a/lib/internal/defaultOptions.js
+++ b/lib/internal/defaultOptions.js
@@ -15,6 +15,7 @@ var defaultOptions =
 	excludeLinksToSamePage: true,
 	filterLevel: 1,
 	honorRobotExclusions: true,
+	shouldLogBroken: false,
 	maxSockets: Infinity,
 	maxSocketsPerHost: 1,
 	rateLimit: 0,

--- a/lib/internal/logToFile.js
+++ b/lib/internal/logToFile.js
@@ -1,0 +1,39 @@
+"use strict";
+
+var fs			   = require('fs');
+var stripAnsi      = require('strip-ansi');
+
+var brokenLinkLogs = "";
+var brokenLinkLogPath = `${__dirname}/brokenLinks.txt`;
+
+var logBrokenToFile = true;
+var shouldDeleteFile = true;
+
+var addToBrokenLogs = function(logData)
+{
+    brokenLinkLogs += `${logData}\n`;   
+};
+
+var clearData = function()
+{   
+    brokenLinkLogs = "";
+};
+
+var write = function()
+{
+    if(shouldDeleteFile === true && fs.existsSync(brokenLinkLogPath))
+    {        
+        fs.unlinkSync(brokenLinkLogPath);
+        shouldDeleteFile = false;
+    }
+
+    fs.appendFileSync(brokenLinkLogPath, stripAnsi(brokenLinkLogs));
+
+    clearData();
+};
+
+module.exports = {
+    addToBrokenLogs: addToBrokenLogs,
+    clearData: clearData,
+    write: write
+  }

--- a/lib/internal/logToFile.js
+++ b/lib/internal/logToFile.js
@@ -1,51 +1,71 @@
 "use strict";
 
-var fs			   = require('fs');
-var path           = require('path');
-var stripAnsi      = require('strip-ansi');
+var fs = require("fs");
+var path = require("path");
+var stripAnsi = require("strip-ansi");
+var os = require("os");
 
-var brokenLinkLogs = "";
-var brokenLinkLogPath = path.resolve(process.cwd(),'brokenLinks.txt');
+var brokenLinksArray = new Array(); //logs buffer
+var outputFile = path.resolve(process.cwd(), "brokenLinks.txt");
+var shouldLogToFile = false; //false by default
 
-var logBrokenToFile;
-var shouldDeleteFile = true;
-
-var enable = function(shouldLog)
-{
-    logBrokenToFile = shouldLog;
+/**
+ * Set if should log to file
+ * @param {boolean} shouldLog if should log to file
+ */
+var enable = function(shouldLog) {
+  shouldLogToFile = shouldLog;
+  if (shouldLogToFile === true) {
+    deleteExistingLogFile();
+  }
 };
 
-var addToBrokenLogs = function(logData)
-{
-    write(`${logData}\n`);
+var deleteExistingLogFile = function() {
+  //Delete file if exist on first entry
+  if (fs.existsSync(outputFile)) {
+    fs.unlinkSync(outputFile);
+  }
 };
 
-var clearData = function()
-{   
-    if(logBrokenToFile === true)
-    {
-        brokenLinkLogs = "";
+/**
+ * add logs to buffer and flush on demand
+ * @param {string} logData result from cli
+ * @param {boolean} shouldFlush should flush to file
+ */
+var addToBrokenLogs = function(logData, shouldFlush) {
+  if (shouldLogToFile === true) {
+    /**
+     * add data to an array
+     * since uses data (with colors) from cli, stripAnsi keeps the string clean
+     */
+    brokenLinksArray.push(`${stripAnsi(logData)}${os.EOL}`);
+
+    if (shouldFlush === true) {
+      flush();
     }
+  }
 };
 
-var write = function(logToWrite)
-{
-    if(logBrokenToFile === true)
-    {
-        if(shouldDeleteFile === true && fs.existsSync(brokenLinkLogPath))
-        {        
-            fs.unlinkSync(brokenLinkLogPath);
-            shouldDeleteFile = false;
-        }
+/**
+ * Reset links array
+ */
+var clearData = function() {
+  brokenLinksArray = [];
+};
 
-        fs.appendFileSync(brokenLinkLogPath, stripAnsi(logToWrite));
-
-        clearData();
-    }
+/**
+ * Flush logs to file
+ */
+var flush = function() {
+    //todo fix it - should not use loop. takes too much time
+    //consider use long string with EOL instead of array
+  for (var line in brokenLinksArray) {
+    fs.appendFileSync(outputFile, brokenLinksArray[line]);
+  }
 };
 
 module.exports = {
-    enable: enable,
-    addToBrokenLogs: addToBrokenLogs,
-    clearData: clearData,
-  }
+  enable: enable,
+  addToBrokenLogs: addToBrokenLogs,
+  clearData: clearData
+};

--- a/lib/internal/logToFile.js
+++ b/lib/internal/logToFile.js
@@ -1,10 +1,11 @@
 "use strict";
 
 var fs			   = require('fs');
+var path           = require('path');
 var stripAnsi      = require('strip-ansi');
 
 var brokenLinkLogs = "";
-var brokenLinkLogPath = `${__dirname}/brokenLinks.txt`;
+var brokenLinkLogPath = path.resolve(process.cwd(),'brokenLinks.txt');
 
 var logBrokenToFile;
 var shouldDeleteFile = true;
@@ -15,10 +16,8 @@ var enable = function(shouldLog)
 };
 
 var addToBrokenLogs = function(logData)
-{   if(logBrokenToFile === true)
-    {
-        brokenLinkLogs += `${logData}\n`;   
-    }
+{
+    write(`${logData}\n`);
 };
 
 var clearData = function()
@@ -29,7 +28,7 @@ var clearData = function()
     }
 };
 
-var write = function()
+var write = function(logToWrite)
 {
     if(logBrokenToFile === true)
     {
@@ -39,7 +38,7 @@ var write = function()
             shouldDeleteFile = false;
         }
 
-        fs.appendFileSync(brokenLinkLogPath, stripAnsi(brokenLinkLogs));
+        fs.appendFileSync(brokenLinkLogPath, stripAnsi(logToWrite));
 
         clearData();
     }
@@ -49,5 +48,4 @@ module.exports = {
     enable: enable,
     addToBrokenLogs: addToBrokenLogs,
     clearData: clearData,
-    write: write
   }

--- a/lib/internal/logToFile.js
+++ b/lib/internal/logToFile.js
@@ -57,8 +57,6 @@ var clearData = function() {
  * Flush logs to file
  */
 var flush = function() {
-    //todo fix it - should not use loop. takes too much time
-    //consider use long string with EOL instead of array
   for (var line in brokenLinksArray) {
     fs.appendFileSync(outputFile, brokenLinksArray[line]);
   }

--- a/lib/internal/logToFile.js
+++ b/lib/internal/logToFile.js
@@ -34,11 +34,9 @@ var deleteExistingLogFile = function() {
  */
 var addToBrokenLogs = function(logData, shouldFlush) {
   if (shouldLogToFile === true) {
-    /**
-     * add data to an array
-     * since uses data (with colors) from cli, stripAnsi keeps the string clean
-     */
-    brokenLinksArray.push(`${stripAnsi(logData)}${os.EOL}`);
+    brokenLinksArray.push(
+      `${stripAnsi(logData).replace(/.*BROKEN\S*/g, "  BROKEN  ")}${os.EOL}`
+    );
 
     if (shouldFlush === true) {
       flush();

--- a/lib/internal/logToFile.js
+++ b/lib/internal/logToFile.js
@@ -6,33 +6,47 @@ var stripAnsi      = require('strip-ansi');
 var brokenLinkLogs = "";
 var brokenLinkLogPath = `${__dirname}/brokenLinks.txt`;
 
-var logBrokenToFile = true;
+var logBrokenToFile;
 var shouldDeleteFile = true;
 
-var addToBrokenLogs = function(logData)
+var enable = function(shouldLog)
 {
-    brokenLinkLogs += `${logData}\n`;   
+    logBrokenToFile = shouldLog;
+};
+
+var addToBrokenLogs = function(logData)
+{   if(logBrokenToFile === true)
+    {
+        brokenLinkLogs += `${logData}\n`;   
+    }
 };
 
 var clearData = function()
 {   
-    brokenLinkLogs = "";
+    if(logBrokenToFile === true)
+    {
+        brokenLinkLogs = "";
+    }
 };
 
 var write = function()
 {
-    if(shouldDeleteFile === true && fs.existsSync(brokenLinkLogPath))
-    {        
-        fs.unlinkSync(brokenLinkLogPath);
-        shouldDeleteFile = false;
+    if(logBrokenToFile === true)
+    {
+        if(shouldDeleteFile === true && fs.existsSync(brokenLinkLogPath))
+        {        
+            fs.unlinkSync(brokenLinkLogPath);
+            shouldDeleteFile = false;
+        }
+
+        fs.appendFileSync(brokenLinkLogPath, stripAnsi(brokenLinkLogs));
+
+        clearData();
     }
-
-    fs.appendFileSync(brokenLinkLogPath, stripAnsi(brokenLinkLogs));
-
-    clearData();
 };
 
 module.exports = {
+    enable: enable,
     addToBrokenLogs: addToBrokenLogs,
     clearData: clearData,
     write: write

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "default-user-agent": "^1.0.0",
     "errno": "~0.1.4",
     "extend": "^3.0.0",
-    "humanize-duration": "^3.9.1",
     "http-equiv-refresh": "^1.0.0",
+    "humanize-duration": "^3.9.1",
     "is-stream": "^1.0.1",
     "is-string": "^1.0.4",
     "limited-request-queue": "^2.0.0",
@@ -31,6 +31,7 @@
     "robot-directives": "~0.3.0",
     "robots-txt-guard": "~0.1.0",
     "robots-txt-parse": "~0.0.4",
+    "strip-ansi": "^4.0.0",
     "urlcache": "~0.7.0",
     "urlobj": "0.0.11"
   },


### PR DESCRIPTION
I needed a clear log for ci, containts broken links only stored in log file.
Added next option to cld:
  --log-broken-links, -b  Log broken links to file

it will generate 'brokenLinks.txt' with the results