### PR TITLE
refactor: drop dependency on Object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "chai-things": "~0.2.0",
     "es6-promise": "^4.1.0",
     "mocha": "^3.0.2",
-    "object.assign": "^4.0.4",
     "slashes": "^1.0.5",
     "st": "^1.2.0"
   },

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -9,25 +9,22 @@ chai.use( require("chai-like") );
 chai.use( require("chai-things") );
 
 require("es6-promise").polyfill();
-require("object.assign").shim();
 
-
-
-module.exports = 
+module.exports =
 {
 	a_an:       testGenerator.a_an,
 	addSlashes: testGenerator.addSlashes,
 	format:     testGenerator.format,
 	//italic:     testGenerator.italic,
-	
+
 	options:    require("./options"),
-	
+
 	startConnection:  server.startConnection,
 	startConnections: server.startConnections,
 	stopConnection:   server.stopConnection,
 	stopConnections:  server.stopConnections,
-	
+
 	tagsString: require("./tagsString"),
-	
+
 	fixture: require("./fixture")
 };

--- a/test/helpers/options.js
+++ b/test/helpers/options.js
@@ -27,10 +27,8 @@ function options(overrides)
 		testDefaultOptions,
 		overrides
 	);
-	
+
 	return parseOptions(overrides);
 }
-
-
 
 module.exports = options;


### PR DESCRIPTION
Modern versions of node.js use a version of v8 that natively supports `Object.assign`.  No need to shim these days :)

Depends on #138 landing first. 