### PR TITLE
Add retry404Head option

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,12 @@ The number of milliseconds to wait before each request.
 ### `options.requestMethod`
 Type: `String`  
 Default value: `"head"`  
-The HTTP request method used in checking links. If you experience problems, try using `"get"`, however `options.retry405Head` should have you covered.
+The HTTP request method used in checking links. If you experience problems, try using `"get"`, however `options.retry404Head` or `options.retry405Head` should have you covered.
+
+### `options.retry404Head`
+Type: `Boolean`  
+Default value: `false`  
+Some servers do not respond correctly to a `"head"` request method. When `true`, a link resulting in an HTTP 404 "Not Found" error will be re-requested using a `"get"` method before deciding that it is broken.
 
 ### `options.retry405Head`
 Type: `Boolean`  

--- a/lib/internal/checkUrl.js
+++ b/lib/internal/checkUrl.js
@@ -55,16 +55,25 @@ function checkUrl(link, baseUrl, cache, options, retry)
 	{
 		discardResponse: true,
 		headers: { "user-agent":options.userAgent },
-		method: retry!==405 ? options.requestMethod : "get"
+		method: (retry!==404 && retry!==405) ? options.requestMethod : "get"
 	})
 	.then( function(response)
 	{
 		response = simpleResponse(response);
 		
-		if (response.statusCode===405 && options.requestMethod==="head" && options.retry405Head===true && retry!==405)
+		if (options.requestMethod==="head")
 		{
-			// Retry possibly broken server with "get"
-			return checkUrl(link, baseUrl, cache, options, 405);
+			if (response.statusCode===404 && options.retry404Head===true && retry!==404)
+			{
+				// Retry possibly broken server with "get"
+				return checkUrl(link, baseUrl, cache, options, 404);
+			}
+			
+			if (response.statusCode===405 && options.retry405Head===true && retry!==405)
+			{
+				// Retry possibly broken server with "get"
+				return checkUrl(link, baseUrl, cache, options, 405);
+			}
 		}
 		
 		// TODO :: store ALL redirected urls in cache

--- a/lib/internal/defaultOptions.js
+++ b/lib/internal/defaultOptions.js
@@ -19,6 +19,7 @@ var defaultOptions =
 	maxSocketsPerHost: 1,
 	rateLimit: 0,
 	requestMethod: "head",
+	retry404Head: false,
 	retry405Head: true,
 	tags: require("./tags"),
 	userAgent: userAgent(pkg.name, pkg.version)


### PR DESCRIPTION
Some websites like http://mjledlighting.com/ return a 404 status code when requested with HEAD (with GET, it's 200). Therefore, I added the retry404Head option which does the same like retry405Head but only for 404 status code.